### PR TITLE
refactor(pipeline): quieten console output to improve performance

### DIFF
--- a/src/model_pipeline/1.1_load_static_inputs.R
+++ b/src/model_pipeline/1.1_load_static_inputs.R
@@ -8,37 +8,107 @@ lookup_assumedParameters_df <- read_csv(file.path(
   "src",
   "lookups",
   "lookup_assumedParameters.csv"
-))
+),
+  col_types=list(
+    Month = col_integer(),
+    Sector = col_character(),
+    StockClass = col_character(),
+    Age = col_double(),
+    Sex = col_character(),
+    SRW_kg = col_double(),
+    LW_kg = col_double(),
+    LWG_kg = col_double(),
+    Velvet_Yield_kg = col_double(),
+    Wool_Yield_kg = col_double(),
+    Days_Pregnant = col_double(),
+    Trimester_Factor = col_double(),
+    Reproduction_Rate = col_double(),
+    FWG_kg = col_double(),
+    Days_Newborn_Fed_Milk = col_double(),
+    Milk_Mother_kg = col_double(),
+    Milk_Newborn_kg = col_double(),
+    MilkPowder_Newborn_kg = col_double(),
+    Milk_Fat_pct = col_double(),
+    Milk_Protein_pct = col_double(),
+    MilkPowder_Protein_pct = col_double(),
+    ME_Diet_AIM = col_double(),
+    DMD_pct_Diet_AIM = col_double(),
+    N_pct_Diet_AIM = col_double()
+  )
+)
 
 lookup_nutrientProfile_pasture_df <- read_csv(file.path(
   "src",
   "lookups",
   "lookup_nutrientProfile_pasture.csv"
-))
+),
+  col_types = list(
+    Pasture_Region = col_character(),
+    Month = col_integer(),
+    Sector = col_character(),
+    ME_Pasture = col_double(),
+    DMD_pct_Pasture = col_double(),
+    N_pct_Pasture = col_double()
+  )
+)
 
 lookup_nutrientProfile_supplements_df <- read_csv(file.path(
   "src",
   "lookups",
   "lookup_nutrientProfile_supplements.csv"
-))
+),
+  col_types = list(
+    SupplementName = col_character(),
+    ME_Supp = col_double(),
+    DMD_pct_Supp = col_double(),
+    N_pct_Supp = col_double()
+  )
+)
 
 lookup_newborn_daily_LWG_profiles_df <- read_csv(file.path(
   "src",
   "lookups",
   "lookup_newborn_daily_LWG_profiles.csv"
-))
+),
+  col_types = list(
+    Sector = col_character(),
+    StockClass = col_character(),
+    BW_kg = col_double(),
+    LWG_kg_day = col_double()
+  )
+)
 
 lookup_newborn_birthdate_milk_df <- read_csv(file.path(
   "src",
   "lookups",
   "lookup_newborn_birthdate_milk.csv"
-))
+),
+  col_types = list(
+    Sector = col_character(),
+    BirthMonth_National = col_integer(),
+    BirthDay_National = col_integer(),
+    Days_Newborn_Fed_OnlyMilk_annual = col_integer(),
+    Days_Newborn_Fed_Milk_annual = col_integer(),
+    Milk_Newborn_kg_annual = col_double(),
+    MilkPowder_Newborn_kg_annual = col_double(),
+    Milk_Fat_pct = col_double(),
+    Milk_Protein_pct = col_double(),
+    MilkPowder_Protein_pct = col_double()
+  )
+)
 
 lookup_slopeFactors_df <- read_csv(file.path(
   "src",
   "lookups",
   "lookup_slopeFactors.csv"
-))
+),
+  col_types = list(
+    Production_Region = col_character(),
+    Primary_Farm_Class = col_character(),
+    N_Urine_Flattish_pct = col_double(),
+    N_Urine_Steep_pct = col_double()
+  )
+)
 
 lookup_location_mapping_df <- read_csv(
   file.path(
@@ -46,5 +116,10 @@ lookup_location_mapping_df <- read_csv(
     "lookups",
     "lookup_location_mapping.csv"
   ),
-  col_select = c("Territory", "Pasture_Region", "Production_Region")
+  col_select = c("Territory", "Pasture_Region", "Production_Region"),
+  col_types = list(
+    Territory = col_character(),
+    Pasture_Region = col_character(),
+    Production_Region = col_character()
+  )
 )

--- a/src/model_pipeline/4_summary_outputs.R
+++ b/src/model_pipeline/4_summary_outputs.R
@@ -46,7 +46,8 @@ summarise_livestock_monthly_by_Sector <- function(df) {
       CH4_DungUrine_kg = sum(CH4_DungUrine_kg),
       CH4_Effluent_kg = sum(CH4_Effluent_kg),
       N2O_DungUrine_kg = sum(N2O_DungUrine_kg),
-      N2O_Effluent_kg = sum(N2O_Effluent_kg)
+      N2O_Effluent_kg = sum(N2O_Effluent_kg),
+      .groups = "drop"
     )
   
   return(out_df)
@@ -62,7 +63,8 @@ summarise_livestock_annual_by_Sector <- function(df) {
       CH4_DungUrine_kg = sum(CH4_DungUrine_kg),
       CH4_Effluent_kg = sum(CH4_Effluent_kg),
       N2O_DungUrine_kg = sum(N2O_DungUrine_kg),
-      N2O_Effluent_kg = sum(N2O_Effluent_kg)
+      N2O_Effluent_kg = sum(N2O_Effluent_kg),
+      .groups = "drop"
     )
   
   return(out_df)

--- a/src/model_pipeline/4_summary_outputs.R
+++ b/src/model_pipeline/4_summary_outputs.R
@@ -80,7 +80,8 @@ summarise_livestock_annual <- function(df) {
       CH4_DungUrine_kg = sum(CH4_DungUrine_kg),
       CH4_Effluent_kg = sum(CH4_Effluent_kg),
       N2O_DungUrine_kg = sum(N2O_DungUrine_kg),
-      N2O_Effluent_kg = sum(N2O_Effluent_kg)
+      N2O_Effluent_kg = sum(N2O_Effluent_kg),
+      .groups = "drop"
     )
   
   return(out_df)
@@ -124,7 +125,8 @@ summarise_all_annual_by_gas <- function(df) {
     summarise(
       CH4_total_kg = sum(CH4_Digestion_kg + CH4_DungUrine_kg + CH4_Effluent_kg),
       N2O_total_kg = sum(N2O_DungUrine_kg + N2O_Effluent_kg + N2O_SynthFert_kg),
-      CO2_total_kg = sum(CO2_SynthFert_kg)
+      CO2_total_kg = sum(CO2_SynthFert_kg),
+      .groups = "drop"
     )
   
   return(out_df)

--- a/src/run_FEM.R
+++ b/src/run_FEM.R
@@ -13,13 +13,13 @@ param_saveout_summary_data = TRUE # TRUE or FALSE (TRUE requires an active param
 
 # load R env --------------------------------------------------------------
 
-library(assertthat)
-library(dplyr)
-library(jsonlite)
-library(lubridate)
-library(purrr)
-library(readr)
-library(tidyr)
+suppressPackageStartupMessages(library(assertthat))
+suppressPackageStartupMessages(library(dplyr))
+suppressPackageStartupMessages(library(jsonlite))
+suppressPackageStartupMessages(library(lubridate))
+suppressPackageStartupMessages(library(purrr))
+suppressPackageStartupMessages(library(readr))
+suppressPackageStartupMessages(library(tidyr))
 
 # run pipeline -------------------------------------------------------------
 


### PR DESCRIPTION
We have observed in production environments these tweaks can improve model runtime for a single farm by ~15%.

They all prevent printouts to console and presetting the lookup data types prevents R from spending time inferring them.