### PR TITLE
refactor(equations): improve performance by changing left joins to inner

### DIFF
--- a/FEM_equations.Rmd
+++ b/FEM_equations.Rmd
@@ -718,9 +718,9 @@ eq_fem4_derive_farm_diet_parameters <- function(
     TRUE ~ "NonDairy"
   )
   
-  # apply sectoral feed allocation
-  SuppFeed_DryMatter_df <- SuppFeed_DryMatter_df %>%
-    left_join( # left join req'd
+  # apply sectoral allocation to supplementary feed
+  supps_df <- SuppFeed_DryMatter_df %>%
+    inner_join(
       SuppFeed_SectoralAllocation_df,
       by="Entity__PeriodEnd"
     ) %>%
@@ -734,8 +734,11 @@ eq_fem4_derive_farm_diet_parameters <- function(
   
   # Part 2.1: Combined supplements diet (excl. pasture) nutritional profile
   
-  SuppFeed_DryMatter_df <- SuppFeed_DryMatter_df %>% 
-    left_join(lookup_nutrientProfile_supplements_df, by="SupplementName") %>% # left join req'd
+  supps_df <- supps_df %>% 
+    inner_join(
+      lookup_nutrientProfile_supplements_df,
+      by="SupplementName"
+    ) %>%
     select(Entity__PeriodEnd, SupplementName, ME_Supp, DMD_pct_Supp, N_pct_Supp, Supp_t_annual) %>%
     group_by(Entity__PeriodEnd) %>%
     mutate(
@@ -744,7 +747,7 @@ eq_fem4_derive_farm_diet_parameters <- function(
     ) %>%
     ungroup()
   
-  inputs_supps_df_agg <- SuppFeed_DryMatter_df %>%
+  supps_df_agg <- supps_df %>%
     summarise(
       .by = Entity__PeriodEnd,
       ME_AllSupps = sum(ME_Supp * Supp_allocation),
@@ -770,7 +773,7 @@ eq_fem4_derive_farm_diet_parameters <- function(
       ME_total_allocation = ME_total_SectorTotal / sum(ME_total_SectorTotal)
     ) %>%
     ungroup() %>%
-    left_join(inputs_supps_df_agg, by="Entity__PeriodEnd") # left_join req'd
+    left_join(supps_df_agg, by="Entity__PeriodEnd") # left_join req'd
   
   # Part 2.3: Determine tonnages and energy contribution of supplements and pasture:
   

--- a/FEM_equations.md
+++ b/FEM_equations.md
@@ -747,9 +747,9 @@ eq_fem4_derive_farm_diet_parameters <- function(
     TRUE ~ "NonDairy"
   )
   
-  # apply sectoral feed allocation
-  SuppFeed_DryMatter_df <- SuppFeed_DryMatter_df %>%
-    left_join( # left join req'd
+  # apply sectoral allocation to supplementary feed
+  supps_df <- SuppFeed_DryMatter_df %>%
+    inner_join(
       SuppFeed_SectoralAllocation_df,
       by="Entity__PeriodEnd"
     ) %>%
@@ -763,8 +763,11 @@ eq_fem4_derive_farm_diet_parameters <- function(
   
   # Part 2.1: Combined supplements diet (excl. pasture) nutritional profile
   
-  SuppFeed_DryMatter_df <- SuppFeed_DryMatter_df %>% 
-    left_join(lookup_nutrientProfile_supplements_df, by="SupplementName") %>% # left join req'd
+  supps_df <- supps_df %>% 
+    inner_join(
+      lookup_nutrientProfile_supplements_df,
+      by="SupplementName"
+    ) %>%
     select(Entity__PeriodEnd, SupplementName, ME_Supp, DMD_pct_Supp, N_pct_Supp, Supp_t_annual) %>%
     group_by(Entity__PeriodEnd) %>%
     mutate(
@@ -773,7 +776,7 @@ eq_fem4_derive_farm_diet_parameters <- function(
     ) %>%
     ungroup()
   
-  inputs_supps_df_agg <- SuppFeed_DryMatter_df %>%
+  supps_df_agg <- supps_df %>%
     summarise(
       .by = Entity__PeriodEnd,
       ME_AllSupps = sum(ME_Supp * Supp_allocation),
@@ -799,7 +802,7 @@ eq_fem4_derive_farm_diet_parameters <- function(
       ME_total_allocation = ME_total_SectorTotal / sum(ME_total_SectorTotal)
     ) %>%
     ungroup() %>%
-    left_join(inputs_supps_df_agg, by="Entity__PeriodEnd") # left_join req'd
+    left_join(supps_df_agg, by="Entity__PeriodEnd") # left_join req'd
   
   # Part 2.3: Determine tonnages and energy contribution of supplements and pasture:
   

--- a/src/FEM_equations.R
+++ b/src/FEM_equations.R
@@ -579,9 +579,9 @@ eq_fem4_derive_farm_diet_parameters <- function(
     TRUE ~ "NonDairy"
   )
   
-  # apply sectoral feed allocation
-  SuppFeed_DryMatter_df <- SuppFeed_DryMatter_df %>%
-    left_join( # left join req'd
+  # apply sectoral allocation to supplementary feed
+  supps_df <- SuppFeed_DryMatter_df %>%
+    inner_join(
       SuppFeed_SectoralAllocation_df,
       by="Entity__PeriodEnd"
     ) %>%
@@ -595,8 +595,11 @@ eq_fem4_derive_farm_diet_parameters <- function(
   
   # Part 2.1: Combined supplements diet (excl. pasture) nutritional profile
   
-  SuppFeed_DryMatter_df <- SuppFeed_DryMatter_df %>% 
-    left_join(lookup_nutrientProfile_supplements_df, by="SupplementName") %>% # left join req'd
+  supps_df <- supps_df %>% 
+    inner_join(
+      lookup_nutrientProfile_supplements_df,
+      by="SupplementName"
+    ) %>%
     select(Entity__PeriodEnd, SupplementName, ME_Supp, DMD_pct_Supp, N_pct_Supp, Supp_t_annual) %>%
     group_by(Entity__PeriodEnd) %>%
     mutate(
@@ -605,7 +608,7 @@ eq_fem4_derive_farm_diet_parameters <- function(
     ) %>%
     ungroup()
   
-  inputs_supps_df_agg <- SuppFeed_DryMatter_df %>%
+  supps_df_agg <- supps_df %>%
     summarise(
       .by = Entity__PeriodEnd,
       ME_AllSupps = sum(ME_Supp * Supp_allocation),
@@ -631,7 +634,7 @@ eq_fem4_derive_farm_diet_parameters <- function(
       ME_total_allocation = ME_total_SectorTotal / sum(ME_total_SectorTotal)
     ) %>%
     ungroup() %>%
-    left_join(inputs_supps_df_agg, by="Entity__PeriodEnd") # left_join req'd
+    left_join(supps_df_agg, by="Entity__PeriodEnd") # left_join req'd
   
   # Part 2.3: Determine tonnages and energy contribution of supplements and pasture:
   


### PR DESCRIPTION
This change tests fine in spite of the "left join req'd" comments.

In addition to improving performance, this prevents invalid supplementary feed inputs (SupplementName not contained in lookup_nutrientProfile_supplements) from contaminating the tonnage of supplements in eq_fem4_derive_farm_diet_parameters.

Have also tidied up a couple of co-located df names.