### PR TITLE
feat!(run_FEM): add param for flexible output selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,27 @@ Run `src/run_FEM.R`
 
 At the head of this script are configurable run parameters for setting:
 - input/output folder locations and file format (CSV/JSON)
-- whether granular results are saved in the output folder
-- whether summary results are saved to the output folder and the level of summarisation
+- output tables to saveout via `param_saveout_tables`
+    - if no saved outputs are desired this can be set to `FALSE` or an empty vector `c()`
+    - the full list of savable outputs is:
+    ```R
+    param_saveout_tables = c(
+        # granular, per module
+        "livestock_results_granular",
+        "fertiliser_results_granular",
+        # summary - detailed, per module
+        "smry_livestock_monthly_by_StockClass",
+        "smry_livestock_monthly_by_Sector",
+        "smry_livestock_annual_by_Sector",
+        "smry_livestock_annual",
+        "smry_fertiliser_annual",
+        # summary - high level, all modules
+        "smry_all_annual_by_emission_type",
+        "smry_all_annual_by_gas"
+        )
+    ```
+
+    Note if a given `Entity_ID` and `Period_End` has no farm data inputs for a specific module (e.g. fertiliser or livestock) if will have no output rows in the per module tables. It will have output rows of zeros in the high level all-module summaries.
 
 ## FEM Equations
 

--- a/src/model_pipeline/4_summary_outputs.R
+++ b/src/model_pipeline/4_summary_outputs.R
@@ -129,21 +129,17 @@ summarise_all_annual_by_gas <- function(df) {
   
 }
 
-# Section 3: Gen summaries according to run parameters --------------------
-
-if (param_summarise_mode != "off") {
+# Section 3: Gen Summaries ------------------------------------------------
   
-  # detailed (per-module) summaries (only farms with input data for relevant module)
-  smry_livestock_monthly_by_StockClass_df <- summarise_livestock_monthly_by_StockClass(livestock_results_granular_df)
-  smry_livestock_monthly_by_Sector_df <- summarise_livestock_monthly_by_Sector(smry_livestock_monthly_by_StockClass_df)
-  smry_livestock_annual_by_Sector_df <- summarise_livestock_annual_by_Sector(smry_livestock_monthly_by_StockClass_df)
-  smry_livestock_annual_df <- summarise_livestock_annual(smry_livestock_annual_by_Sector_df)
-  smry_fertiliser_annual_df <- summarise_fertiliser_annual(fertiliser_results_granular_df)
-  # high level summaries (all farms)
-  smry_all_annual_by_emission_type_df <- summarise_all_annual_by_emission_type(smry_livestock_annual_df, smry_fertiliser_annual_df)
-  smry_all_annual_by_gas_df <- summarise_all_annual_by_gas(smry_all_annual_by_emission_type_df)
-  
-}
+# detailed (per-module) summaries (only farms with input data for relevant module)
+smry_livestock_monthly_by_StockClass_df <- summarise_livestock_monthly_by_StockClass(livestock_results_granular_df)
+smry_livestock_monthly_by_Sector_df <- summarise_livestock_monthly_by_Sector(smry_livestock_monthly_by_StockClass_df)
+smry_livestock_annual_by_Sector_df <- summarise_livestock_annual_by_Sector(smry_livestock_monthly_by_StockClass_df)
+smry_livestock_annual_df <- summarise_livestock_annual(smry_livestock_annual_by_Sector_df)
+smry_fertiliser_annual_df <- summarise_fertiliser_annual(fertiliser_results_granular_df)
+# high level summaries (all farms)
+smry_all_annual_by_emission_type_df <- summarise_all_annual_by_emission_type(smry_livestock_annual_df, smry_fertiliser_annual_df)
+smry_all_annual_by_gas_df <- summarise_all_annual_by_gas(smry_all_annual_by_emission_type_df)
 
 # Section 4: Format Outputs -----------------------------------------------
 
@@ -166,19 +162,15 @@ deconcat_join_key <- function(df) {
   
 }
 
-if (param_summarise_mode != "off") {
-  
-  # granular outputs
-  livestock_results_granular_df <- deconcat_join_key(livestock_results_granular_df)
-  fertiliser_results_granular_df <- deconcat_join_key(fertiliser_results_granular_df)
-  # detailed (per-module) summaries
-  smry_livestock_monthly_by_StockClass_df <- deconcat_join_key(smry_livestock_monthly_by_StockClass_df)
-  smry_livestock_monthly_by_Sector_df <- deconcat_join_key(smry_livestock_monthly_by_Sector_df)
-  smry_livestock_annual_by_Sector_df <- deconcat_join_key(smry_livestock_annual_by_Sector_df)
-  smry_livestock_annual_df <- deconcat_join_key(smry_livestock_annual_df)
-  smry_fertiliser_annual_df <- deconcat_join_key(smry_fertiliser_annual_df)
-  # high level summaries
-  smry_all_annual_by_emission_type_df <- deconcat_join_key(smry_all_annual_by_emission_type_df)
-  smry_all_annual_by_gas_df <- deconcat_join_key(smry_all_annual_by_gas_df)
-  
-}
+# granular (per-module) outputs
+livestock_results_granular_df <- deconcat_join_key(livestock_results_granular_df)
+fertiliser_results_granular_df <- deconcat_join_key(fertiliser_results_granular_df)
+# detailed (per-module) summaries
+smry_livestock_monthly_by_StockClass_df <- deconcat_join_key(smry_livestock_monthly_by_StockClass_df)
+smry_livestock_monthly_by_Sector_df <- deconcat_join_key(smry_livestock_monthly_by_Sector_df)
+smry_livestock_annual_by_Sector_df <- deconcat_join_key(smry_livestock_annual_by_Sector_df)
+smry_livestock_annual_df <- deconcat_join_key(smry_livestock_annual_df)
+smry_fertiliser_annual_df <- deconcat_join_key(smry_fertiliser_annual_df)
+# high level summaries
+smry_all_annual_by_emission_type_df <- deconcat_join_key(smry_all_annual_by_emission_type_df)
+smry_all_annual_by_gas_df <- deconcat_join_key(smry_all_annual_by_gas_df)

--- a/src/model_pipeline/5_saveout.R
+++ b/src/model_pipeline/5_saveout.R
@@ -1,163 +1,50 @@
-# parse system datetime for appending to output filenames
+# check param_saveout_tables
 
-sys_datetime <- format(Sys.time(), "%Y-%m-%d_%H%M%S")
-
-# Section 1: Granular calculation data -----------------------------------
-
-if (param_saveout_granular_calculation_data == TRUE) {
-  # Create output directory if it doesn't exist
-  if (!dir.exists(param_output_path)) {
-    dir.create(param_output_path, recursive = TRUE)
+if(!isFALSE(param_saveout_tables) && length(param_saveout_tables) > 0) {
+  
+  # parse system datetime for appending to output filenames
+  
+  sys_datetime <- format(Sys.time(), "%Y-%m-%d_%H%M%S")
+  
+  tables_to_save <- setNames(
+    lapply(param_saveout_tables, function(x) get(paste0(x, "_df"))),
+    param_saveout_tables
+  )
+  
+  if(length(tables_to_save) > 0) {
+    
+    # create output dir
+    if (!dir.exists(param_output_path)) {
+      dir.create(param_output_path, recursive = TRUE)
+    }
   }
   
-  if (param_output_data_format == "csv") {
-    # Livestock
-    write_csv(livestock_results_granular_df,
-              file.path(
-                param_output_path,
-                paste0("livestock_results_granular_", sys_datetime, ".csv")
-              ))
+  if(param_output_data_format == "csv") {
     
-    # Fertiliser
-    write_csv(fertiliser_results_granular_df,
-              file.path(
-                param_output_path,
-                paste0("fertiliser_results_granular_", sys_datetime, ".csv")
-              ))
+    # Save out all tables as CSV files
+    for (table_name in param_saveout_tables) {
+      table_df <- get(paste0(table_name, "_df"))
+      write_csv(
+        table_df,
+        file.path(
+          param_output_path,
+          paste0(table_name, "_", sys_datetime, ".csv")
+        )
+      )
+      
+    }
     
-  } else if (param_output_data_format == "json") {
-    # Save out granular calculation data
+  } else if(param_output_data_format == "json") {
     
-    # Livestock
+    # saveout one json file
     write_json(
-      list(
-        livestock_results_granular = livestock_results_granular_df,
-        fertiliser_results_granular = fertiliser_results_granular_df
-      ),
+      tables_to_save,
       file.path(
         param_output_path,
-        paste0("results_granular_", sys_datetime, ".json")
-      )
+        paste0("output_", sys_datetime, ".json")
+      ),
+      digits=NA
     )
-    
-  }
   
-}
-
-# Section 2: Summary data ------------------------------------------------
-
-if (param_saveout_summary_data == TRUE) {
-  # Create output directory if it doesn't exist
-  if (!dir.exists(param_output_path)) {
-    dir.create(param_output_path, recursive = TRUE)
   }
-  
-  # Save out summarised data
-  if (param_output_data_format == "csv") {
-    if (param_summarise_mode == 'detailed-only' ||
-        param_summarise_mode == 'all') {
-      # Detailed (per-module) summaries
-      write_csv(
-        smry_livestock_monthly_by_StockClass_df,
-        file.path(
-          param_output_path,
-          paste0(
-            "smry_livestock_monthly_by_StockClass_",
-            sys_datetime,
-            ".csv"
-          )
-        )
-      )
-      
-      write_csv(smry_livestock_monthly_by_Sector_df,
-                file.path(
-                  param_output_path,
-                  paste0(
-                    "smry_livestock_monthly_by_Sector_",
-                    sys_datetime,
-                    ".csv"
-                  )
-                ))
-      
-      write_csv(smry_livestock_annual_by_Sector_df,
-                file.path(
-                  param_output_path,
-                  paste0(
-                    "smry_livestock_annual_by_Sector_",
-                    sys_datetime,
-                    ".csv"
-                  )
-                ))
-      
-      write_csv(smry_livestock_annual_df,
-                file.path(
-                  param_output_path,
-                  paste0("smry_livestock_annual_", sys_datetime, ".csv")
-                ))
-      
-      write_csv(smry_fertiliser_annual_df,
-                file.path(
-                  param_output_path,
-                  paste0("smry_fertiliser_annual_", sys_datetime, ".csv")
-                ))
-      
-    }
-    
-    if (param_summarise_mode == 'highLevel-only' ||
-        param_summarise_mode == "all") {
-      # High level summaries (all farms)
-      write_csv(smry_all_annual_by_emission_type_df,
-                file.path(
-                  param_output_path,
-                  paste0(
-                    "smry_all_annual_by_emission_type_",
-                    sys_datetime,
-                    ".csv"
-                  )
-                ))
-      
-      write_csv(smry_all_annual_by_gas_df,
-                file.path(
-                  param_output_path,
-                  paste0("smry_all_annual_by_gas_", sys_datetime, ".csv")
-                ))
-      
-    }
-    
-  } else if (param_output_data_format == "json") {
-    if (param_summarise_mode == "detailed-only" ||
-        param_summarise_mode == "all") {
-      write_json(
-        list(
-          smry_livestock_monthly_by_StockClass = smry_livestock_monthly_by_StockClass_df,
-          smry_livestock_monthly_by_Sector = smry_livestock_monthly_by_Sector_df,
-          smry_livestock_annual_by_Sector = smry_livestock_annual_by_Sector_df,
-          smry_livestock_annual = smry_livestock_annual_df,
-          smry_fertiliser_annual = smry_fertiliser_annual_df
-        ),
-        file.path(
-          param_output_path,
-          paste0("smry_detailed_", sys_datetime, ".json")
-        )
-      )
-      
-    }
-    
-    if (param_summarise_mode == "highLevel-only" ||
-        param_summarise_mode == "all") {
-      write_json(
-        list(
-          smry_all_annual_by_emission_type = smry_all_annual_by_emission_type_df,
-          smry_all_annual_by_gas = smry_all_annual_by_gas_df
-        ),
-        file.path(
-          param_output_path,
-          paste0("smry_highLevel_", sys_datetime, ".json")
-        )
-      )
-      
-    }
-    
-  }
-  
 }

--- a/src/model_pipeline/5_saveout.R
+++ b/src/model_pipeline/5_saveout.R
@@ -11,58 +11,59 @@ if(!isFALSE(param_saveout_tables) && length(param_saveout_tables) > 0) {
     param_saveout_tables
   )
   
+  print("Emissions estimation completed.")
+  
   if(length(tables_to_save) > 0) {
     
     # create output dir
     if (!dir.exists(param_output_path)) {
       dir.create(param_output_path, recursive = TRUE)
     }
-  }
   
-  if(param_output_data_format == "csv") {
-    
-    print("Emissions estimation completed.")
-    
-    # Save out all tables as CSV files
-    for (table_name in param_saveout_tables) {
-      table_df <- get(paste0(table_name, "_df"))
-      write_csv(
-        table_df,
+    if(param_output_data_format == "csv") {
+      
+      # Save out all tables as CSV files
+      for (table_name in param_saveout_tables) {
+        table_df <- get(paste0(table_name, "_df"))
+        write_csv(
+          table_df,
+          file.path(
+            param_output_path,
+            paste0(table_name, "_", sys_datetime, ".csv")
+          )
+        )
+        
+        print(paste0("Results saved out to ", file.path(param_output_path, paste0(table_name, "_", sys_datetime, ".csv"))))
+      }
+      
+    } else if(param_output_data_format == "json") {
+      
+      # saveout one json file
+      write_json(
+        tables_to_save,
         file.path(
           param_output_path,
-          paste0(table_name, "_", sys_datetime, ".csv")
-        )
+          paste0("output_", sys_datetime, ".json")
+        ),
+        digits=NA
       )
       
-      print(paste0("Results saved out to ", file.path(param_output_path, paste0(table_name, "_", sys_datetime, ".csv"))))
+      print(paste0("Results saved out to ",
+                   file.path(param_output_path, paste0("output_", sys_datetime, ".json"))))
       
     }
     
-  } else if(param_output_data_format == "json") {
+    # print to console any cases of saved out tables having zero rows:
     
-    # saveout one json file
-    write_json(
-      tables_to_save,
-      file.path(
-        param_output_path,
-        paste0("output_", sys_datetime, ".json")
-      ),
-      digits=NA
-    )
-    
-    print(paste0("Emissions estimation completed. Results saved out to ",
-                 file.path(param_output_path, paste0("output_", sys_datetime, ".json"))))
-    
-  }
-  
-  # print to console any cases of saved out tables having zero rows:
-  
-  for (table_name in param_saveout_tables) {
-    table_df <- get(paste0(table_name, "_df"))
-    if (nrow(table_df) == 0) {
-      print(paste0("Note: Table '", table_name, "' has zero rows as no farm data inputs for this module were provided"))
+    for (table_name in param_saveout_tables) {
+      table_df <- get(paste0(table_name, "_df"))
+      if (nrow(table_df) == 0) {
+        print(paste0("Note: Table '", table_name, "' has zero rows as no farm data inputs for this module were provided"))
+      }
+      
     }
-  }
+    
+  } 
   
 } else {
   

--- a/src/model_pipeline/5_saveout.R
+++ b/src/model_pipeline/5_saveout.R
@@ -21,6 +21,8 @@ if(!isFALSE(param_saveout_tables) && length(param_saveout_tables) > 0) {
   
   if(param_output_data_format == "csv") {
     
+    print("Emissions estimation completed.")
+    
     # Save out all tables as CSV files
     for (table_name in param_saveout_tables) {
       table_df <- get(paste0(table_name, "_df"))
@@ -31,6 +33,8 @@ if(!isFALSE(param_saveout_tables) && length(param_saveout_tables) > 0) {
           paste0(table_name, "_", sys_datetime, ".csv")
         )
       )
+      
+      print(paste0("Results saved out to ", file.path(param_output_path, paste0(table_name, "_", sys_datetime, ".csv"))))
       
     }
     
@@ -45,6 +49,23 @@ if(!isFALSE(param_saveout_tables) && length(param_saveout_tables) > 0) {
       ),
       digits=NA
     )
-  
+    
+    print(paste0("Emissions estimation completed. Results saved out to ",
+                 file.path(param_output_path, paste0("output_", sys_datetime, ".json"))))
+    
   }
+  
+  # print to console any cases of saved out tables having zero rows:
+  
+  for (table_name in param_saveout_tables) {
+    table_df <- get(paste0(table_name, "_df"))
+    if (nrow(table_df) == 0) {
+      print(paste0("Note: Table '", table_name, "' has zero rows as no farm data inputs for this module were provided"))
+    }
+  }
+  
+} else {
+  
+  print('Emissions estimation completed. No files saved out.')
+  
 }

--- a/src/run_FEM.R
+++ b/src/run_FEM.R
@@ -7,9 +7,12 @@ param_input_data_format = "csv" # csv or json
 param_output_path = "data_output" # this will be created if it doesn't exist
 param_output_data_format = "csv" # csv or json
 
-param_saveout_granular_calculation_data = FALSE # TRUE or FALSE
-param_summarise_mode = "highLevel-only" # off / detailed-only / highLevel-only / all
-param_saveout_summary_data = TRUE # TRUE or FALSE (TRUE requires an active param_summarise_mode)
+# set output tables to saveout, refer to README
+param_saveout_tables = c(
+  "smry_livestock_annual",
+  "smry_all_annual_by_emission_type",
+  "smry_all_annual_by_gas"
+)
 
 # load R env --------------------------------------------------------------
 
@@ -43,7 +46,6 @@ source(file.path("src", "model_pipeline", "3.1_livestock.R"))
 source(file.path("src", "model_pipeline", "3.2_fertiliser.R"))
 
 # Step 4: Summarise outputs
-# - as configured by run parameters
 
 source(file.path("src", "model_pipeline", "4_summary_outputs.R"))
 


### PR DESCRIPTION
Enable users to flexibly select outputs via param_saveout_tables. Supercedes 3 existing run_FEM.R parameters which are now deprecated:

- `param_saveout_granular_calculation_data`
- `param_summarise_mode`
- `param_saveout_summary_data`

Also print to console which outputs were saved out, their location and note if any have zero rows.