### PR TITLE
fix(data_input_validation.R): val_Breed_Allocation_StockClass_present() such that check is applied on a farm level, consistent with Breed_Allocation.csv

### DIFF
--- a/src/data_input_validation.R
+++ b/src/data_input_validation.R
@@ -234,21 +234,18 @@ val_Breed_Allocation_StockClass_present <- function() {
   
   if(nrow(Breed_Allocation_df) > 0) {
     
-    stockclass_with_breed_allocation_no_stock_df <- setdiff(Breed_Allocation_df %>% 
-                                                              select(Entity__PeriodEnd, StockClass),
-                                                            StockRec_monthly_df %>%
-                                                              filter(StockClass %in% c("Dairy Heifers R1", "Dairy Heifers R2", "Milking Cows Mature"),
-                                                                     StockCount_mean > 0) %>%
-                                                              select(Entity__PeriodEnd, StockClass) %>% 
-                                                              distinct()) %>% 
-      group_by(Entity__PeriodEnd) %>% 
-      summarise(StockClass = paste(StockClass, collapse = ", "),
-                .groups = "drop") %>% 
-      mutate(Entity__PeriodEnd__StockClass = paste0(Entity__PeriodEnd, " (StockClass: ", StockClass, ")"))
-    
-    if(nrow(stockclass_with_breed_allocation_no_stock_df) > 0) {
-      stop(paste0("Breed allocation for some StockClass are provided but there are no stock on the following farms (or StockClass provided is not a female dairy StockClass): ", 
-                  paste(stockclass_with_breed_allocation_no_stock_df$Entity__PeriodEnd__StockClass, collapse = ", ")))
+    farms_with_breed_allocation_no_stock <- setdiff(Breed_Allocation_df %>% 
+                                                      pull(Entity__PeriodEnd) %>% 
+                                                      unique(),
+                                                    StockRec_monthly_df %>%
+                                                      filter(StockClass %in% c("Dairy Heifers R1", "Dairy Heifers R2", "Milking Cows Mature"),
+                                                             StockCount_mean > 0) %>%
+                                                      pull(Entity__PeriodEnd) %>% 
+                                                      unique())
+                                                              
+    if(length(farms_with_breed_allocation_no_stock) > 0) {
+      stop(paste0("Breed allocation for the following farms are provided but there are no female dairy StockClass present: ", 
+                  farms_with_breed_allocation_no_stock))
     }
     
   }

--- a/src/data_input_validation.R
+++ b/src/data_input_validation.R
@@ -245,7 +245,7 @@ val_Breed_Allocation_StockClass_present <- function() {
                                                               
     if(length(farms_with_breed_allocation_no_stock) > 0) {
       stop(paste0("Breed allocation for the following farms are provided but there are no female dairy StockClass present: ", 
-                  farms_with_breed_allocation_no_stock))
+                  paste(farms_with_breed_allocation_no_stock, collapse = ", ")))
     }
     
   }


### PR DESCRIPTION
This validation ensures that female dairy stock is present if breed allocation is provided. It’s also supposed to check that the stock classes in breed allocation table are present on the farm. But stock class is actually not an input in the raw breed allocation table.

When we added breed allocation in the beta release, the breed allocation input was manipulated in the preprocessing script such that a weighted average liveweight is calculated for all three female dairy stock classes, regardless of whether these stock classes are present on the farm or not.

This form of the breed allocation table (as opposed to the less granular original input table, which was agnostic to stock class) was carried through as we later added the validation script. Hence, the validation was done on a stock class level, even though as per raw user input, this is not possible.

This PR revises the validation so that the check will be applied on a farm level (presence of female dairy stock) rather than stock class.

