### PR TITLE
refactor(data_input_validation.R): replace column index with column name in val_SuppFeed_DryMatter_Sector_present() as requested by BSI

### DIFF
--- a/src/data_input_validation.R
+++ b/src/data_input_validation.R
@@ -263,8 +263,8 @@ val_SuppFeed_DryMatter_Sector_present <-function() {
   if(any(SuppFeed_DryMatter_df$Dry_Matter_t > 0, na.rm = TRUE)) {
     
     sectors_fed_supps_without_stock_df <- setdiff(SuppFeed_DryMatter_df %>%
-                                                    select(Entity__PeriodEnd, 4:7) %>% 
-                                                    gather(key = "Sector", value = "Allocation", 2:5) %>% 
+                                                    select(Entity__PeriodEnd, Beef_Allocation, Dairy_Allocation, Deer_Allocation, Sheep_Allocation) %>% 
+                                                    gather(key = "Sector", value = "Allocation", Beef_Allocation, Dairy_Allocation, Deer_Allocation, Sheep_Allocation) %>% 
                                                     mutate(Sector = gsub('.{11}$', '', Sector)) %>% 
                                                     group_by(Entity__PeriodEnd, Sector) %>% 
                                                     summarise(Allocation = sum(Allocation),


### PR DESCRIPTION
Column order is preserved in R during data manipulation hence indexing columns in the code doesn't cause any issues. However, this was flagged as an issue by BSI on their end.